### PR TITLE
fix typo and condition

### DIFF
--- a/cs-6200/03-P2L2-threads-and-concurrency.md
+++ b/cs-6200/03-P2L2-threads-and-concurrency.md
@@ -133,7 +133,7 @@ Consider the scenario of a single thread `T1` making a disk request.
   * Upon receiving the request, the disk requires time `t`<sub>`idle`</sub> to fulfill the request (i.e., time required to move the disk spindle, access the appropriate data, and then respond to the request).
   * During `t`<sub>`idle`</sub>, thread `T1` cannot perform any useful work and instead must wait for the response (i.e., the CPU is **idle** during this time).
 
-If `t`<sub>`idle`</sub> is longer than the time required to perform a context switch, then it may be sensible to perform a context switch to another thread (e.g., `T2`) during this time instead. In particular, `t`<sub>`idle`</sub> `>=` `2t`<sub>`ctx_switch`</sub> is the critical point at which context switching can "hide" idling time.
+If `t`<sub>`idle`</sub> is longer than the time required to perform a context switch, then it may be sensible to perform a context switch to another thread (e.g., `T2`) during this time instead. In particular, `t`<sub>`idle`</sub> `>` `2t`<sub>`ctx_switch`</sub> is the critical point at which context switching can "hide" idling time.
   * This applies to both processes and threads, however, recall that one of the most costly steps during a context switch is the time required to create the new virtual-to-physical memory mapping of the address space for the new process that will be scheduled. However, given that threads ***share*** an address space, when context switching among ***threads*** it is ***not*** necessary to recreate ***new*** virtual-to-physical memory mapping.
   * Therefore, because this costly step is avoided, in general `t`<sub>`ctx_switch`</sub> is less among threads than among processes. Correspondingly, it is much more likely the critical point will be reached when using threads, and so threads can be effectively used in this manner to **hide latency** (i.e., by being productive during idling time), even on a ***single*** CPU.
 
@@ -1060,7 +1060,7 @@ With respect to the toy shop example, the corresponding ***steps*** are as label
   * in step 1, the boss thread accepts the order, and then immediately passes it onto the worker threads
   * each of the worker threads will subsequently perform steps 2-6 
 
-The **throughout** of the system is limited by the boss thread, therefore, the boss thread must be kept as ***efficient*** as possible (e.g., the boss thread must execute on every newly arriving order). The throughout is therefore characterized as follows:
+The **throughput** of the system is limited by the boss thread, therefore, the boss thread must be kept as ***efficient*** as possible (e.g., the boss thread must execute on every newly arriving order). The throughout is therefore characterized as follows:
 <center>
 <img src="./assets/P02L02-061.gif">
 </center>


### PR DESCRIPTION
according to the lecture: https://www.youtube.com/watch?v=uYlaQN1qqxQ&t=664s, it's `>` instead of `>=`, it's correct on https://github.com/awpala/my-omscs-notes/blob/main/cs-6200/06-P2L5-thread-performance-considerations.md#14-event-driven-model-why